### PR TITLE
WIP: Make travis run using ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,8 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='transforms3d'
-        # For this package-template, we include examples of Cython modules,
-        # so Cython is required for testing. If your package does not include
-        # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='numpy scipy astropy cffi sphinx matplotlib'
+        - DEBUG=True
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
+language: python
+
+python:
+    - 2.7
+    - 3.5
+
 sudo: false
 
 addons:
   apt:
     packages:
     - graphviz
+    - texlive-latex-extra
+    - dvipng
 
 cache:
   pip: true
@@ -11,7 +19,25 @@ cache:
   #  - $HOME/marxs-5.1.0
   #  - $HOME/build/Chandra-MARX/marxs/marx/
 
-language: python
+env:
+    global:
+        # The following versions are the 'default' for tests, unless
+        # overridden underneath. They are defined here in order to save having
+        # to repeat them for all configurations.
+        - NUMPY_VERSION=stable
+        - ASTROPY_VERSION=stable
+        - SETUP_CMD='test'
+        - PIP_DEPENDENCIES='transforms3d'
+        # For this package-template, we include examples of Cython modules,
+        # so Cython is required for testing. If your package does not include
+        # Cython code, you can set CONDA_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='numpy scipy astropy cffi sphinx matplotlib'
+    matrix:
+        # Make sure that egg_info works without dependencies
+        - SETUP_CMD='egg_info'
+        # Try all python versions with the latest numpy
+        - SETUP_CMD='test'
+
 
 before_install:
   - wget ftp://space.mit.edu/pub/cxc/marx/v5.1/marx-dist-5.1.0.tar.gz
@@ -21,44 +47,75 @@ before_install:
   - cd ..
 
 install:
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy cffi sphinx matplotlib ipython
-  - source activate test-environment
-  - pip install transforms3d
-  - pip install alabaster --upgrade
-  # Set the location the MARX c code and compiled version in setup.cfg
-  - sed -i.bak s/'srcdir ='/'srcdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx-5\.1\.0\/'/g setup.cfg
-  - sed -i.bak s/'libdir ='/'libdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx\/lib\/'/g setup.cfg
-  - python setup.py install
+    # Set the location the MARX c code and compiled version in setup.cfg
+    - sed -i.bak s/'srcdir ='/'srcdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx-5\.1\.0\/'/g setup.cfg
+    - sed -i.bak s/'libdir ='/'libdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx\/lib\/'/g setup.cfg
+
+    # We now use the ci-helpers package to set up our testing environment.
+    # This is done by using Miniconda and then using conda and pip to install
+    # dependencies. Which dependencies are installed using conda and pip is
+    # determined by the CONDA_DEPDENDENCIES and PIP_DEPENDENCIES variables,
+    # which should be space-delimited lists of package names. See the README
+    # in https://github.com/astropy/ci-helpers for information about the full
+    # list of environment variables that can be used to customize your
+    # environment. In some cases, ci-helpers may not offer enough flexibility
+    # in how to install a package, in which case you can have additional
+    # commands in the install: section below.
+
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+
+    # As described above, using ci-helpers, you should be able to set up an
+    # environment with dependencies installed using conda and pip, but in some
+    # cases this may not provide enough flexibility in how to install a
+    # specific dependency (and it will not be able to install non-Python
+    # dependencies). Therefore, you can also include commands below (as
+    # well as at the start of the install section or in the before_install
+    # section if they are needed before setting up conda) to install any
+    # other dependencies.
+
+    # - pip install alabaster --upgrade
 
 matrix:
     include:
 
-        # Check for sphinx doc build warnings
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage'
-	- os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='sphinx-build docs docs/_build -W'
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='python setup.py test'
-	  
+        # Do a coverage test in Python 2.
+        - python: 2.7
+          env: SETUP_CMD='test --coverage'
+
+        # Check for sphinx doc build warnings - we do this first because it
+        # may run for a long time
+        - python: 2.7
+          env: SETUP_CMD='build_sphinx -w'
+
+        # Try Astropy development version
+        - python: 2.7
+          env: ASTROPY_VERSION=development
+        - python: 3.5
+          env: ASTROPY_VERSION=development
+        # - python: 2.7
+        #   env: ASTROPY_VERSION=lts
+        # - python: 3.5
+        #  env: ASTROPY_VERSION=lts
+
+        # Try older numpy versions
+        - python: 2.7
+          env: NUMPY_VERSION=1.10
+        - python: 2.7
+          env: NUMPY_VERSION=1.9
+        - python: 2.7
+          env: NUMPY_VERSION=1.8
+        - python: 2.7
+          env: NUMPY_VERSION=1.7
+
+        # Try numpy pre-release
+        - python: 3.5
+          env: NUMPY_VERSION=prerelease
+
 
 script:
-    - $SETUP_CMD
+   - python setup.py $SETUP_CMD
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ before_install:
 install:
 
     # Set the location the MARX c code and compiled version in setup.cfg
-    - sed -i.bak s/'srcdir ='/'srcdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx-5\.1\.0\/'/g setup.cfg
-    - sed -i.bak s/'libdir ='/'libdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx\/lib\/'/g setup.cfg
+    - sed -i.bak 's|srcdir =|srcdir = '"$(echo $TRAVIS_BUILD_DIR)"'/marx-5.1.0/|g' setup.cfg
+    - sed -i.bak 's|libdir =|libdir = '"$(echo $TRAVIS_BUILD_DIR)"'/marx/lib/|g' setup.cfg
 
     # We now use the ci-helpers package to set up our testing environment.
     # This is done by using Miniconda and then using conda and pip to install

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,18 @@ matrix:
 
         # Check for sphinx doc build warnings
         - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage'
+	- os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='sphinx-build docs docs/_build -W'
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='python setup.py test'
+	  
 
 script:
     - $SETUP_CMD
+
+after_success:
+    # If coveralls.io is set up for this package, uncomment the line
+    # below and replace "packagename" with the name of your package.
+    # The coveragerc file may be customized as needed for your package.
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='marxs/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='transforms3d'
-        - CONDA_DEPENDENCIES='numpy scipy astropy cffi sphinx matplotlib'
+        - CONDA_DEPENDENCIES='scipy cffi sphinx matplotlib'
         - DEBUG=True
     matrix:
         # Make sure that egg_info works without dependencies

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ Multi-Architecture-Raytrace-Xraymission-Simulator
    :target: https://travis-ci.org/Chandra-MARX/marxs
    :alt: Continuous integration status
 
-.. image:: https://readthedocs.io/projects/marxs/badge/?version=latest
-   :target: http://marxs.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/marxs/badge/?version=latest
+   :target: http://marxs.readthedocs.io/en/latest/
    :alt: Documentation Status
 
 .. image:: https://coveralls.io/repos/github/chandra-marx/marxs/badge.svg?branch=master

--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,17 @@ marxs
 Multi-Architecture-Raytrace-Xraymission-Simulator
 
 .. image:: https://travis-ci.org/Chandra-MARX/marxs.svg
-    :target: https://travis-ci.org/Chandra-MARX/marxs
+   :target: https://travis-ci.org/Chandra-MARX/marxs
+   :alt: Continuous integration status
+
+.. image:: https://readthedocs.io/projects/marxs/badge/?version=latest
+   :target: http://marxs.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
+.. image:: https://coveralls.io/repos/github/chandra-marx/marxs/badge.svg?branch=master
+   :target: https://coveralls.io/github/chandra-marx/marxs?branch=master
+   :alt: Fraction of code covered by tests
+
+.. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
+   :target: http://www.astropy.org/
+   :alt: Powered by astropy

--- a/marxs/optics/grating.py
+++ b/marxs/optics/grating.py
@@ -107,9 +107,13 @@ class FlatGrating(FlatOpticalElement):
     d : float
         grating constant
     order_selector : callable
-        A function or callable object that accepts photon energy, polarization and the blaze angle
-        as input and returns a grating order (integer)
-        and a probability (float).
+        A function or callable object that accepts arrays of photon energy, polarization
+        and the blaze angle
+        as input and returns arrays for  grating order (integer)
+        and probability (float). The probabiliy expresses the chance that the photon passes
+        the grating and is not absorbed, e.g. if the probability that a photon at energy E ends
+        up in order=[-2, -1, 0, 1, 2] is [0, 0, .5, .3, .0] , then the returned probability for
+        all photons should be 0.8.
     transmission : bool
         Set to ``True`` for a transmission grating and to ``False`` for a
         reflection grating. (*Default*: ``True`` )

--- a/marxs/optics/marx_build.py
+++ b/marxs/optics/marx_build.py
@@ -14,9 +14,9 @@ conf.read('setup.cfg')
 marxscr = conf.get('MARX', 'srcdir')
 marxlib = conf.get('MARX', 'libdir')
 
-sources = [('pfile', 'src', 'pfile.c'), ('libsrc', 'mirror.c')]
+sources = [('pfile', 'src', 'pfile.c'), ('marx', 'libsrc', 'mirror.c')]
 headers = [('pfile', 'src'), ('jdmath', 'src') , ('jdfits', 'src'),
-           ('src',), ('libsrc',)]
+           ('marx', 'src',), ('marx', 'libsrc',)]
 
 ffi.set_source("_marx",
 '''

--- a/marxs/optics/marx_build.py
+++ b/marxs/optics/marx_build.py
@@ -1,5 +1,5 @@
 from os import path
-from ConfigParser import ConfigParser
+from six.moves.configparser import ConfigParser
 from cffi import FFI
 
 with open ("marxs/optics/cdef.txt", "r") as myfile:

--- a/marxs/optics/marx_build.py
+++ b/marxs/optics/marx_build.py
@@ -14,9 +14,9 @@ conf.read('setup.cfg')
 marxscr = conf.get('MARX', 'srcdir')
 marxlib = conf.get('MARX', 'libdir')
 
-sources = [('pfile', 'src', 'pfile.c'), ('marx', 'libsrc', 'mirror.c')]
+sources = [('pfile', 'src', 'pfile.c'), ('libsrc', 'mirror.c')]
 headers = [('pfile', 'src'), ('jdmath', 'src') , ('jdfits', 'src'),
-           ('marx', 'src'), ('marx', 'libsrc')]
+           ('src',), ('libsrc',)]
 
 ffi.set_source("_marx",
 '''

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import sys
 # To use a consistent encoding
 from codecs import open
 from os import path
-from ConfigParser import ConfigParser, NoOptionError
+
+from six.moves.configparser import ConfigParser, NoOptionError
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
@@ -84,9 +85,9 @@ setup_args = {
     #     'hello': ['*.msg'],
     # },
 
-    'setup_requires': ["astropy>=1.0", "transforms3d", "sphinx"],
-    'install_requires': ["sphinx"],
-    'requires': ['sphinx'],
+    'setup_requires': ["six", "astropy>=1.0", "transforms3d", "sphinx"],
+    'install_requires': ["six", "sphinx"],
+    'requires': ["six", 'sphinx'],
     'tests_require': ['pytest'],
     'zip_safe': False,
     }

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,9 @@ setup_args = {
     #     'hello': ['*.msg'],
     # },
 
-    'setup_requires': ["astropy>=1.0", "transforms3d"],
-    'install_requires': [],
+    'setup_requires': ["astropy>=1.0", "transforms3d", "sphinx"],
+    'install_requires': ["sphinx"],
+    'requires': ['sphinx'],
     'tests_require': ['pytest'],
     'zip_safe': False,
     }

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup_args = {
     #     'hello': ['*.msg'],
     # },
 
-    'setup_requires': ["six", "astropy>=1.0", "transforms3d", "sphinx"],
+    'setup_requires': ["setuptools", "six", "astropy>=1.0", "transforms3d", "sphinx"],
     'install_requires': ["six", "sphinx"],
     'requires': ["six", 'sphinx'],
     'tests_require': ['pytest'],


### PR DESCRIPTION
This should make travis run, at least on python2.7. There are some py3 incompatibility in the code (e.g. ConfigParser) so the py 3.5 tests still fail.

Also the egg files don't build yet, as the dependencies are not fully listed in the setup file.
